### PR TITLE
adds support for extended bases

### DIFF
--- a/storage/boltz/store.go
+++ b/storage/boltz/store.go
@@ -57,7 +57,7 @@ type BaseStore struct {
 	symbols       map[string]EntitySymbol
 	publicSymbols []string
 	mapSymbols    map[string]*entityMapSymbol
-
+	isExtended    bool
 	Indexer
 	links           map[string]LinkCollection
 	entityNotFoundF func(id string) error
@@ -96,9 +96,15 @@ func (store *BaseStore) GetOrCreateEntitiesBucket(tx *bbolt.Tx) *TypedBucket {
 func (store *BaseStore) GetEntityBucket(tx *bbolt.Tx, id []byte) *TypedBucket {
 	baseBucket := store.GetEntitiesBucket(tx)
 	entityBucket := baseBucket.GetBucket(string(id))
+
 	if store.parent == nil {
 		return entityBucket
 	}
+
+	if entityBucket == nil {
+		return nil
+	}
+	entityBucket.extended = store.isExtended
 	return entityBucket.GetPath(store.entityPath...)
 }
 
@@ -151,6 +157,11 @@ func (store *BaseStore) AddDeleteHandler(handler EntityChangeHandler) {
 
 func (store *BaseStore) GetSingularEntityType() string {
 	return GetSingularEntityType(store.entityType)
+}
+
+func (store *BaseStore) Extended() *BaseStore {
+	store.isExtended = true
+	return store
 }
 
 func GetSingularEntityType(entityType string) string {

--- a/storage/boltz/typed_bucket.go
+++ b/storage/boltz/typed_bucket.go
@@ -100,6 +100,19 @@ type TypedBucket struct {
 	*bbolt.Bucket
 	parent *TypedBucket
 	errorz.ErrorHolderImpl
+	extended bool
+}
+
+func (bucket *TypedBucket) Extended() *TypedBucket {
+	bucket.extended = true
+	return bucket
+}
+
+func (bucket *TypedBucket) Tx() *bbolt.Tx {
+	if bucket.Bucket == nil && bucket.extended {
+		return bucket.parent.Tx()
+	}
+	return bucket.Bucket.Tx()
 }
 
 func (bucket *TypedBucket) GetParent() *TypedBucket {
@@ -168,6 +181,10 @@ func (bucket *TypedBucket) GetPath(path ...string) *TypedBucket {
 	for _, pathElem := range path {
 		next = next.GetBucket(pathElem)
 		if next == nil {
+			if bucket.extended {
+				return newTypedBucket(bucket, nil).Extended()
+			}
+
 			return nil
 		}
 	}


### PR DESCRIPTION
- allows a store to receive entities even if a child bucket is empty
- useful in situations where the the store owner is being proxied via
another external store